### PR TITLE
Resolve Issue with Empty Rows in getRow and getOne

### DIFF
--- a/src/query-helper.ts
+++ b/src/query-helper.ts
@@ -170,7 +170,9 @@ export class QueryHelper<X extends object> {
   }
 
   async getOne<T = unknown>(...args: QueryTemplateOrSimpleQuery) {
-    return this.#query(args).then((x) => Object.values(x.rows?.[0])?.[0] as T);
+    return this.#query<[T]>(args).then(
+      (x) => Object.values(x.rows?.[0] ?? {})?.[0] as T | undefined
+    );
   }
 
   async getCount(...args: QueryTemplateOrSimpleQuery) {

--- a/src/query-helper.ts
+++ b/src/query-helper.ts
@@ -166,7 +166,7 @@ export class QueryHelper<X extends object> {
   }
 
   async getRow<T extends QueryResultRow>(...args: QueryTemplateOrSimpleQuery) {
-    return this.#query<T>(args).then((x) => x.rows?.[0]);
+    return this.#query<T>(args).then((x) => x.rows?.[0] as T | undefined);
   }
 
   async getOne<T = unknown>(...args: QueryTemplateOrSimpleQuery) {


### PR DESCRIPTION
This pull request addresses two issues regarding the handling of empty rows in `getRow` and `getOne` methods in `QueryHelper` class. Here are the main changes:

1. In `getRow`, a type definition has been added for empty rows. This ensures that the type returned by `getRow` includes the possibility of an `undefined` value. This change makes the typing more accurate and prevents potential type-related errors.

2. The `getOne` method previously had an issue when an empty line was present. This has been fixed by providing a default value (`{}`) when no row is present. This ensures that the `Object.values()` call won't fail due to being called on `undefined`.