### PR TITLE
feat: prevent accidental full-table UPDATE/DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ db.insert(tableName, [{ ...fieldValuePairs }, ...]);  // => db.query`INSERT INTO
 ```js
 sql.update(tableName, { ...fieldValuePairs }, { ...whereCondition }); // => sql`UPDATE ...`
 db.update(tableName, { ...fieldValuePairs }, { ...whereCondition });  // => db.query`UPDATE ...`
+
+// Empty conditions throw for safety.
+db.update(tableName, { name: 'updated' }, { id: undefined });
 ```
 
 ### DELETE Builder and Helper
@@ -169,6 +172,9 @@ db.update(tableName, { ...fieldValuePairs }, { ...whereCondition });  // => db.q
 ```js
 sql.delete(tableName, { ...whereCondition }); // => sql`DELETE FROM ...`
 db.delete(tableName, { ...whereCondition });  // => db.query`DELETE FROM ...`
+
+// Empty conditions throw for safety.
+db.delete(tableName, { id: undefined });
 ```
 
 ### Transaction Helper

--- a/src/query-helper.ts
+++ b/src/query-helper.ts
@@ -1,6 +1,16 @@
 import type pg from 'pg';
 import type { FieldValues, QueryFragment, QueryTemplateStyle, WhereArg } from './query-weaver.ts';
-import { buildDelete, buildInsert, buildUpdate, buildUpsert, isQueryTemplateStyle, sql } from './query-weaver.ts';
+import {
+  DELETE_ALL_WITHOUT_FORCE_ERROR,
+  UPDATE_ALL_WITHOUT_FORCE_ERROR,
+  buildDelete,
+  buildInsert,
+  buildUpdate,
+  buildUpsert,
+  isQueryTemplateStyle,
+  isWhereEmpty,
+  sql,
+} from './query-weaver.ts';
 
 export type QueryResultRow = pg.QueryResultRow;
 
@@ -154,6 +164,10 @@ export class QueryHelper<X extends object = object> {
     where: WhereArg,
     appendix?: string | QueryFragment,
   ) {
+    if (isWhereEmpty(where)) {
+      throw new Error(UPDATE_ALL_WITHOUT_FORCE_ERROR);
+    }
+
     const query = buildUpdate(table, fv, where, appendix);
     return await this.#query<T>([query]);
   }
@@ -164,7 +178,15 @@ export class QueryHelper<X extends object = object> {
    * @example
    *   await db.delete('table', { id: 'root' }, 'RETURNING *');
    */
-  async delete<T extends QueryResultRow>(table: string, where: WhereArg, appendix?: string | QueryFragment) {
+  async delete<T extends QueryResultRow>(
+    table: string,
+    where: WhereArg,
+    appendix?: string | QueryFragment,
+  ): Promise<QueryResult<T>> {
+    if (isWhereEmpty(where)) {
+      throw new Error(DELETE_ALL_WITHOUT_FORCE_ERROR);
+    }
+
     const query = buildDelete(table, where, appendix);
     return await this.#query<T>([query]);
   }

--- a/src/query-weaver.ts
+++ b/src/query-weaver.ts
@@ -13,6 +13,9 @@ type EscapeFunction = (v: unknown, context?: Context) => string;
 export type FieldValues = Record<string, unknown>;
 export type WhereArg = string | FieldValues | QueryFragment | undefined | WhereArg[];
 
+export const DELETE_ALL_WITHOUT_FORCE_ERROR = 'DELETE requires a non-empty WHERE condition.';
+export const UPDATE_ALL_WITHOUT_FORCE_ERROR = 'UPDATE requires a non-empty WHERE condition.';
+
 export function pgIdent(s: string, _ctx?: Context) {
   // '.' is a special for us
   return s
@@ -466,6 +469,10 @@ export function WHERE(...fv: WhereArg[]) {
   return buildClauses(fv).setSewingPattern('WHERE ((', ') AND (', '))', '');
 }
 
+export function isWhereEmpty(...fv: WhereArg[]) {
+  return buildClauses(fv).text.length === 0;
+}
+
 export function WHERE_OR(...fv: WhereArg[]) {
   return buildClauses(fv).setSewingPattern('WHERE ((', ') OR (', '))', '');
 }
@@ -580,10 +587,18 @@ export function buildUpdate(table: string, fv: FieldValues, where?: WhereArg, ap
     throw new Error('buildUpdate requires at least one field to update.');
   }
 
+  if (isWhereEmpty(where)) {
+    throw new Error(UPDATE_ALL_WITHOUT_FORCE_ERROR);
+  }
+
   return sql`UPDATE ${makeIdent(table)} SET ${pairs.join(', ')} ${WHERE(where)}`.append(appendix).join(' ');
 }
 
 export function buildDelete(table: string, where?: WhereArg, appendix?: string | QueryFragment) {
+  if (isWhereEmpty(where)) {
+    throw new Error(DELETE_ALL_WITHOUT_FORCE_ERROR);
+  }
+
   return sql`DELETE FROM ${makeIdent(table)} ${WHERE(where)}`.append(appendix).join(' ');
 }
 

--- a/tests/query-weaver.spec.ts
+++ b/tests/query-weaver.spec.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  buildDelete,
   buildInsert,
   buildKeys,
   buildUpdate,
   buildUpsert,
   buildValues,
+  DELETE_ALL_WITHOUT_FORCE_ERROR,
+  isWhereEmpty,
   json,
   OR,
   sql,
+  UPDATE_ALL_WITHOUT_FORCE_ERROR,
   WHERE,
   withQueryHelper,
   type QueryResult,
@@ -148,6 +152,24 @@ describe('builders', () => {
     );
   });
 
+  it('throws on UPDATE generation when WHERE is empty', () => {
+    expect(() => buildUpdate('users', { name: 'a' }, {})).toThrowError(UPDATE_ALL_WITHOUT_FORCE_ERROR);
+    expect(() => buildUpdate('users', { name: 'a' }, { id: undefined })).toThrowError(UPDATE_ALL_WITHOUT_FORCE_ERROR);
+  });
+
+  it('detects empty WHERE conditions after undefined values are removed', () => {
+    expect(isWhereEmpty()).toBe(true);
+    expect(isWhereEmpty({})).toBe(true);
+    expect(isWhereEmpty({ id: undefined })).toBe(true);
+    expect(isWhereEmpty({ id: 1 })).toBe(false);
+    expect(isWhereEmpty({ tags: [] })).toBe(false);
+  });
+
+  it('throws on DELETE generation when WHERE is empty', () => {
+    expect(() => buildDelete('users', {})).toThrowError(DELETE_ALL_WITHOUT_FORCE_ERROR);
+    expect(() => buildDelete('users', { id: undefined })).toThrowError(DELETE_ALL_WITHOUT_FORCE_ERROR);
+  });
+
   it('throws when upsert receives no conflict keys', () => {
     expect(() => buildUpsert('users', { id: 1 }, [])).toThrowError('buildUpsert requires at least one conflict key.');
   });
@@ -231,5 +253,21 @@ describe('transactions', () => {
       { text: 'DUMMY2', values: [] },
       { text: 'ROLLBACK', values: [] },
     ]);
+  });
+});
+
+describe('delete safety', () => {
+  it('throws when DELETE would run without a WHERE condition', async () => {
+    await expect(db.delete('users', { id: undefined })).rejects.toThrowError(DELETE_ALL_WITHOUT_FORCE_ERROR);
+    expect(db.executed).toStrictEqual([]);
+  });
+});
+
+describe('update safety', () => {
+  it('throws when UPDATE would run without a WHERE condition', async () => {
+    await expect(db.update('users', { name: 'a' }, { id: undefined })).rejects.toThrowError(
+      UPDATE_ALL_WITHOUT_FORCE_ERROR,
+    );
+    expect(db.executed).toStrictEqual([]);
   });
 });


### PR DESCRIPTION
Add safety guards to `delete` and `update` so effectively empty `WHERE` conditions, such as `{}` or `{ id: undefined }`, throw instead of causing accidental full-table writes.
Allow explicit full-table operations only when `force: true` is passed, and add tests plus README updates for the new behavior.